### PR TITLE
Accept non-number values as an argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 module.exports = function (n) {
-	return toString.call(n) === '[object Number]' && n > 0;
+	return Math.sign(n) > 0;
 };

--- a/test.js
+++ b/test.js
@@ -5,6 +5,6 @@ test(t => {
 	t.true(m(1));
 	t.false(m(0));
 	t.false(m(-1));
-	t.false(m('1'));
+	t.true(m('1'));
 	t.true(m(Number(1)));
 });


### PR DESCRIPTION
Ok, first of all the fact that this abomination even exists makes me sad. Especially after what happened yesterday when one stupid package got removed from npm.

But if some people really rely on it, then at least let's try to avoid hacking. 
Now, there is a thing called `Math` basic lib in JavaScript. So why on Earth not use that ? Not only we don't have to use magic with `call` and bla, but also we get a real number !! How cool is that ? But because the API here uses boolean values then so be it.
Also - I'm not really sure why `'1'` should be false ? This lib is called `isPositive` and not `isNumber`.

Completely unrelated but I've seen somebody commiting this : 
`Accept 'Number' object`. First of all, as we all know we should not be using `new` with `Number` etc. Secondly - there was no test for that. Something along these lines (notice we have to explicitly tell linters to ignore this as it's a really bad practice:

```
    /* jshint ignore:start */
    t.notOk(m(new Number(-2)));
    /* jshint ignore:end */
```

Really last thing - please don't brake JavaScript.
